### PR TITLE
semi-fix for review_tags

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -47,5 +47,7 @@ class SpotsController < ApplicationController
     average_rating = rating_sum / @spot.reviews.count
     @average_rating = average_rating.to_f
 
+    @reviews = @spot.reviews
+
   end
 end

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -4,7 +4,9 @@
       <%= cl_image_tag @spot.photo.key, class: "img-show" %>
       <h2 class="show-title text-center"><%= @spot.name %></h2>
       <p class="text-center"><%= star_rating(@average_rating, 5) %></p>
-      <p><%=review.tags.map(&:name) %></p>
+      <% if @reviews.first.tags.count > 0 %>
+        <p><%= @reviews.first.tags.map(&:name) %></p>
+      <% end %>
       <div class="description-section">
         <h3 class="show-h3">Description</h3>
         <p><%= @spot.description %></p>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,6 +9,7 @@
 #   end
 require "open-uri"
 
+ReviewsTag.destroy_all
 Review.destroy_all
 Spot.destroy_all
 Category.destroy_all


### PR DESCRIPTION
did a bandaid-fix for the reviews_tag push from Ajmal.
previously it tried to list all tag_names for a "review" with the following line:
`review.tags.map(&:name)`

However this instance of "review" was not defined and no instance of review was passed onto the show method. Additionally, from what I can see the logic would have printed endless amounts of tags onto the show page if a spot would have many reviews with tags.

Therefore I adjusted the logic to only take the first review of a spot and print its tags, only if there are any tags present at all.

To make this work I applied a "bandaid" change in the spots_controller by simply passing all reviews of a spot based on the params (i.e. spot_id). This might not take followings into account and just take any review for a spot, I need to test this later on. But for now it is working and displayed properly, sufficient for a demo if we cannot fix it properly