### PR TITLE
fixed stars

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,8 +5,13 @@ module ApplicationHelper
     empty_star = '☆'
 
     if rating > 0
-      full_stars = full_star * rating
-      empty_stars = empty_star * (out_of - rating)
+      rounded_rating = rating.round(1)
+      full_stars_count = rounded_rating.floor
+      additional_star = (rounded_rating - full_stars_count) >= 0.5 ? 1 : 0
+      empty_stars_count = out_of - full_stars_count - additional_star
+
+      full_stars = full_star * (full_stars_count + additional_star.to_i)
+      empty_stars = empty_star * empty_stars_count.to_i
       content_tag(:span, full_stars + empty_stars, class: 'star-rating')
     else
       content_tag(:span, "No review", class: 'star-rating')


### PR DESCRIPTION
stars now properly take floats into account.

if the average rating decimal is .5 or higher, a full star will be displayed, if it is below .5 a empty star will be used instead.

unfortunately half stars arent implementable this way